### PR TITLE
allow for more than 64 items

### DIFF
--- a/multichoose.go
+++ b/multichoose.go
@@ -1,14 +1,36 @@
 package multichoose
 
 type MultiChoose struct {
-	selected uint64
+	selected []uint64
 	length   int
 	limit    int
 }
 
+func (mc *MultiChoose) getSelected(index int) bool {
+	if index < 0 || index > mc.length {
+		return false
+	}
+	i := uint64(index) >> 6
+	j := uint64(index) & 0x3F
+	return (mc.selected[i] & (1 << j)) != 0
+}
+
+func (mc *MultiChoose) setSelected(index int, value bool) {
+	if index < 0 || index > mc.length {
+		return
+	}
+	i := uint64(index) >> 6
+	j := uint64(index) & 0x3F
+	if value {
+		mc.selected[i] |= (1 << j)
+	} else {
+		mc.selected[i] &^= (1 << j)
+	}
+}
+
 func New(length int) *MultiChoose {
 	return &MultiChoose{
-		selected: 0,
+		selected: make([]uint64, (length>>6)+1),
 		length:   length,
 		limit:    -1,
 	}
@@ -17,8 +39,8 @@ func New(length int) *MultiChoose {
 func (mc MultiChoose) Count() int {
 	count := 0
 	for i := 0; i <= mc.length; i++ {
-		if mc.selected>>i&1 == 1 {
-			count += 1
+		if mc.getSelected(i) {
+			count++
 		}
 	}
 	return count
@@ -29,21 +51,13 @@ func (mc *MultiChoose) Select(index int) {
 		return
 	}
 
-	curr := uint64(1) << index
-	mc.selected = mc.selected | curr
+	mc.setSelected(index, true)
 }
 
 func (mc *MultiChoose) Deselect(index int) {
-	curr := uint64(1) << index
-	mc.selected = mc.selected & (^curr)
+	mc.setSelected(index, false)
 }
 
 func (mc MultiChoose) IsSelected(index int) bool {
-	i := uint64(index)
-	curr := uint64(1) << i
-	if (mc.selected & curr) != 0 {
-		return true
-	} else {
-		return false
-	}
+	return mc.getSelected(index)
 }

--- a/multichoose_test.go
+++ b/multichoose_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestMultiChoose(t *testing.T) {
-	mc := multichoose.New(5)
-	require.Equal(t, 5, mc.Length())
+	mc := multichoose.New(100)
+	require.Equal(t, 100, mc.Length())
 
 	for i := 0; i < mc.Length(); i++ {
 		require.Equal(t, false, mc.IsSelected(i))
@@ -26,13 +26,13 @@ func TestMultiChoose(t *testing.T) {
 		require.Equal(t, false, mc.IsSelected(i))
 	}
 
-	mc.SetLimit(2)
+	mc.SetLimit(50)
 
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 50; i++ {
 		mc.Select(i)
 		require.Equal(t, true, mc.IsSelected(i))
 	}
-	for i := 2; i < mc.Length(); i++ {
+	for i := 50; i < mc.Length(); i++ {
 		mc.Select(i)
 		require.Equal(t, false, mc.IsSelected(i))
 	}
@@ -44,7 +44,7 @@ func TestMultiChoose(t *testing.T) {
 }
 
 func TestMultiChooseToggle(t *testing.T) {
-	mc := multichoose.New(5)
+	mc := multichoose.New(100)
 
 	for i := 0; i < mc.Length(); i++ {
 		mc.Toggle(i)


### PR DESCRIPTION
Fixes and closes #1 
Not sure how you feel about this. I assume since you used a uint64 and bit shifting to store the selected indexes that you were trying to be as space conscious as possible, so I tried to keep as much of that as I could.